### PR TITLE
Update CMSIS-FreeRTOS files for node apps

### DIFF
--- a/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Include/freertos_mpool.h
+++ b/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Include/freertos_mpool.h
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------
- * Copyright (c) 2013-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -29,26 +29,26 @@
 
 /* Memory Pool implementation definitions */
 #define MPOOL_STATUS              0x5EED0000U
-#define MPOOL_SEM                 StaticSemaphore_t
 
 /* Memory Block header */
 typedef struct {
   void *next;                   /* Pointer to next block  */
-} MPOOL_BLOCK;
+} MemPoolBlock_t;
 
 /* Memory Pool control block */
 typedef struct MemPoolDef_t {
-  MPOOL_BLOCK *head;            /* Pointer to head block  */
-  MPOOL_SEM    sem;             /* Pool semaphore object  */
-  uint8_t     *mem_arr;         /* Pool memory array      */
-  uint32_t     mem_sz;          /* Pool memory array size */
-  const
-  char        *name;            /* Pointer to name string */
-  uint32_t     bl_sz;           /* Size of a single block */
-  uint32_t     bl_cnt;          /* Number of blocks       */
-  uint32_t     n;               /* Block allocation index */
-  volatile
-  uint32_t     status;          /* Object status flags    */
+  MemPoolBlock_t    *head;      /* Pointer to head block   */
+  SemaphoreHandle_t  sem;       /* Pool semaphore handle   */
+  uint8_t           *mem_arr;   /* Pool memory array       */
+  uint32_t           mem_sz;    /* Pool memory array size  */
+  const char        *name;      /* Pointer to name string  */
+  uint32_t           bl_sz;     /* Size of a single block  */
+  uint32_t           bl_cnt;    /* Number of blocks        */
+  uint32_t           n;         /* Block allocation index  */
+  volatile uint32_t  status;    /* Object status flags     */
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+  StaticSemaphore_t  mem_sem;   /* Semaphore object memory */
+#endif
 } MemPool_t;
 
 /* No need to hide static object type, just align to coding style */

--- a/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
+++ b/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------
- * Copyright (c) 2013-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,12 +28,23 @@
 
 #include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
 
+#if defined(_RTE_)
 #include "RTE_Components.h"             // Component selection
 #include CMSIS_device_header
 
 /* Configuration and component setup check */
 #if defined(RTE_Compiler_EventRecorder)
-  #define USE_TRACE_EVENT_RECORDER
+  #if !defined(EVR_FREERTOS_DISABLE)
+    #define USE_TRACE_EVENT_RECORDER
+    /*
+      FreeRTOS provides functions and hooks to support execution tracing. This
+      functionality is only enabled if configUSE_TRACE_FACILITY == 1.
+      Set #define configUSE_TRACE_FACILITY 1 in FreeRTOSConfig.h to enable trace events.
+    */
+    #if (configUSE_TRACE_FACILITY == 0)
+      #error "Definition configUSE_TRACE_FACILITY must equal 1 to enable FreeRTOS trace events."
+    #endif
+  #endif
 #endif
 
 #if defined(RTE_RTOS_FreeRTOS_HEAP_1)
@@ -43,46 +54,275 @@
 #if defined(RTE_RTOS_FreeRTOS_HEAP_5)
   #define USE_FreeRTOS_HEAP_5
 #endif
+#endif /* _RTE_ */
 
-/* Check FreeRTOSConfig.h include definitions.
-   Note: CMSIS-RTOS API requires functions included by using following definitions.
-         In case if certain API function is not used compiler will optimize it away.
+/*
+  CMSIS-RTOS2 FreeRTOS image size optimization definitions.
+  Note: Definitions configUSE_OS2 can be used to optimize FreeRTOS image size when
+        certain functionality is not required when using CMSIS-RTOS2 API.
+        In general optimization decisions are left to the tool chain but in cases
+        when coding style prevents it to optimize the code following optional
+        definitions can be used.
+*/
+
+/*
+  Option to exclude CMSIS-RTOS2 functions osThreadSuspend and osThreadResume from
+  the application image.
+*/
+#ifndef configUSE_OS2_THREAD_SUSPEND_RESUME
+#define configUSE_OS2_THREAD_SUSPEND_RESUME   1
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 function osThreadEnumerate from the application image.
+*/
+#ifndef configUSE_OS2_THREAD_ENUMERATE
+#define configUSE_OS2_THREAD_ENUMERATE        1
+#endif
+
+/*
+  Option to disable CMSIS-RTOS2 function osEventFlagsSet and osEventFlagsClear
+  operation from ISR.
+*/
+#ifndef configUSE_OS2_EVENTFLAGS_FROM_ISR
+#define configUSE_OS2_EVENTFLAGS_FROM_ISR     1
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Thread Flags API functions from the application image.
+*/
+#ifndef configUSE_OS2_THREAD_FLAGS
+#define configUSE_OS2_THREAD_FLAGS            configUSE_TASK_NOTIFICATIONS
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Timer API functions from the application image.
+*/
+#ifndef configUSE_OS2_TIMER
+#define configUSE_OS2_TIMER                   configUSE_TIMERS
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Mutex API functions from the application image.
+*/
+#ifndef configUSE_OS2_MUTEX
+#define configUSE_OS2_MUTEX                   configUSE_MUTEXES
+#endif
+
+
+/*
+  CMSIS-RTOS2 FreeRTOS configuration check (FreeRTOSConfig.h).
+  Note: CMSIS-RTOS API requires functions included by using following definitions.
+        In case if certain API function is not used compiler will optimize it away.
 */
 #if (INCLUDE_xSemaphoreGetMutexHolder == 0)
-  #error "Definition INCLUDE_xSemaphoreGetMutexHolder must be non-zero to implement Mutex Management API."
+  /*
+    CMSIS-RTOS2 function osMutexGetOwner uses FreeRTOS function xSemaphoreGetMutexHolder. In case if
+    osMutexGetOwner is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_xSemaphoreGetMutexHolder 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xSemaphoreGetMutexHolder must equal 1 to implement Mutex Management API."
 #endif
 #if (INCLUDE_vTaskDelay == 0)
-  #error "Definition INCLUDE_vTaskDelay must be non-zero to implement Generic Wait Functions API."
+  /*
+    CMSIS-RTOS2 function osDelay uses FreeRTOS function vTaskDelay. In case if
+    osDelay is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskDelay 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelay must equal 1 to implement Generic Wait Functions API."
 #endif
 #if (INCLUDE_vTaskDelayUntil == 0)
-  #error "Definition INCLUDE_vTaskDelayUntil must be non-zero to implement Generic Wait Functions API."
+  /*
+    CMSIS-RTOS2 function osDelayUntil uses FreeRTOS function vTaskDelayUntil. In case if
+    osDelayUntil is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskDelayUntil 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelayUntil must equal 1 to implement Generic Wait Functions API."
 #endif
 #if (INCLUDE_vTaskDelete == 0)
-  #error "Definition INCLUDE_vTaskDelete must be non-zero to implement Thread Management API."
+  /*
+    CMSIS-RTOS2 function osThreadTerminate and osThreadExit uses FreeRTOS function
+    vTaskDelete. In case if they are not used in the application image, compiler
+    will optimize them away.
+    Set #define INCLUDE_vTaskDelete 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelete must equal 1 to implement Thread Management API."
 #endif
 #if (INCLUDE_xTaskGetCurrentTaskHandle == 0)
-  #error "Definition INCLUDE_xTaskGetCurrentTaskHandle must be non-zero to implement Thread Management API."
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function xTaskGetCurrentTaskHandle to implement
+    functions osThreadGetId, osThreadFlagsClear and osThreadFlagsGet. In case if these
+    functions are not used in the application image, compiler will optimize them away.
+    Set #define INCLUDE_xTaskGetCurrentTaskHandle 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskGetCurrentTaskHandle must equal 1 to implement Thread Management API."
 #endif
 #if (INCLUDE_xTaskGetSchedulerState == 0)
-  #error "Definition INCLUDE_xTaskGetSchedulerState must be non-zero to implement Kernel Information and Control API."
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function xTaskGetSchedulerState to implement Kernel
+    tick handling and therefore it is vital that xTaskGetSchedulerState is included into
+    the application image.
+    Set #define INCLUDE_xTaskGetSchedulerState 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskGetSchedulerState must equal 1 to implement Kernel Information and Control API."
 #endif
 #if (INCLUDE_uxTaskGetStackHighWaterMark == 0)
-  #error "Definition INCLUDE_uxTaskGetStackHighWaterMark must be non-zero to implement Thread Management API."
+  /*
+    CMSIS-RTOS2 function osThreadGetStackSpace uses FreeRTOS function uxTaskGetStackHighWaterMark.
+    In case if osThreadGetStackSpace is not used in the application image, compiler will
+    optimize it away.
+    Set #define INCLUDE_uxTaskGetStackHighWaterMark 1 to fix this error.
+  */
+  #error "Definition INCLUDE_uxTaskGetStackHighWaterMark must equal 1 to implement Thread Management API."
 #endif
 #if (INCLUDE_uxTaskPriorityGet == 0)
-  #error "Definition INCLUDE_uxTaskPriorityGet must be non-zero to implement Thread Management API."
+  /*
+    CMSIS-RTOS2 function osThreadGetPriority uses FreeRTOS function uxTaskPriorityGet. In case if
+    osThreadGetPriority is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_uxTaskPriorityGet 1 to fix this error.
+  */
+  #error "Definition INCLUDE_uxTaskPriorityGet must equal 1 to implement Thread Management API."
 #endif
 #if (INCLUDE_vTaskPrioritySet == 0)
-  #error "Definition INCLUDE_vTaskPrioritySet must be non-zero to implement Thread Management API."
+  /*
+    CMSIS-RTOS2 function osThreadSetPriority uses FreeRTOS function vTaskPrioritySet. In case if
+    osThreadSetPriority is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskPrioritySet 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskPrioritySet must equal 1 to implement Thread Management API."
 #endif
 #if (INCLUDE_eTaskGetState == 0)
-  #error "Definition INCLUDE_eTaskGetState must be non-zero to implement Thread Management API."
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function vTaskDelayUntil to implement functions osThreadGetState
+    and osThreadTerminate. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define INCLUDE_eTaskGetState 1 to fix this error.
+  */
+  #error "Definition INCLUDE_eTaskGetState must equal 1 to implement Thread Management API."
 #endif
 #if (INCLUDE_vTaskSuspend == 0)
-  #error "Definition INCLUDE_vTaskSuspend must be non-zero to implement Kernel Information and Control API."
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS functions vTaskSuspend and vTaskResume to implement
+    functions osThreadSuspend and osThreadResume. In case if these functions are not
+    used in the application image, compiler will optimize them away.
+    Set #define INCLUDE_vTaskSuspend 1 to fix this error.
+    Alternatively, if the application does not use osThreadSuspend and
+    osThreadResume they can be excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_SUSPEND_RESUME 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_SUSPEND_RESUME == 1)
+    #error "Definition INCLUDE_vTaskSuspend must equal 1 to implement Kernel Information and Control API."
+  #endif
 #endif
 #if (INCLUDE_xTimerPendFunctionCall == 0)
-  #error "Definition INCLUDE_xTimerPendFunctionCall must be non-zero to implement Event Flags API."
+  /*
+    CMSIS-RTOS2 function osEventFlagsSet and osEventFlagsClear, when called from
+    the ISR, call FreeRTOS functions xEventGroupSetBitsFromISR and
+    xEventGroupClearBitsFromISR which are only enabled if timers are operational and
+    xTimerPendFunctionCall in enabled.
+    Set #define INCLUDE_xTimerPendFunctionCall 1 and #define configUSE_TIMERS 1
+    to fix this error.
+    Alternatively, if the application does not use osEventFlagsSet and osEventFlagsClear
+    from the ISR their operation from ISR can be restricted by setting:
+    #define configUSE_OS2_EVENTFLAGS_FROM_ISR 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 1)
+    #error "Definition INCLUDE_xTimerPendFunctionCall must equal 1 to implement Event Flags API."
+  #endif
+#endif
+
+#if (configUSE_TIMERS == 0)
+  /*
+    CMSIS-RTOS2 Timer Management API functions use FreeRTOS timer functions to implement
+    timer management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_TIMERS 1 to fix this error.
+    Alternatively, if the application does not use timer functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_TIMER 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_TIMER == 1)
+    #error "Definition configUSE_TIMERS must equal 1 to implement Timer Management API."
+  #endif
+#endif
+
+#if (configUSE_MUTEXES == 0)
+  /*
+    CMSIS-RTOS2 Mutex Management API functions use FreeRTOS mutex functions to implement
+    mutex management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_MUTEXES 1 to fix this error.
+    Alternatively, if the application does not use mutex functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_MUTEX 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_MUTEX == 1)
+    #error "Definition configUSE_MUTEXES must equal 1 to implement Mutex Management API."
+  #endif
+#endif
+
+#if (configUSE_COUNTING_SEMAPHORES == 0)
+  /*
+    CMSIS-RTOS2 Memory Pool functions use FreeRTOS function xSemaphoreCreateCounting
+    to implement memory pools. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_COUNTING_SEMAPHORES 1 to fix this error.
+  */
+  #error "Definition configUSE_COUNTING_SEMAPHORES must equal 1 to implement Memory Pool API."
+#endif
+#if (configUSE_TASK_NOTIFICATIONS == 0)
+  /*
+    CMSIS-RTOS2 Thread Flags API functions use FreeRTOS Task Notification functions to implement
+    thread flag management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_TASK_NOTIFICATIONS 1 to fix this error.
+    Alternatively, if the application does not use thread flags functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_FLAGS 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_FLAGS == 1)
+    #error "Definition configUSE_TASK_NOTIFICATIONS must equal 1 to implement Thread Flags API."
+  #endif
+#endif
+
+#if (configUSE_TRACE_FACILITY == 0)
+  /*
+    CMSIS-RTOS2 function osThreadEnumerate requires FreeRTOS function uxTaskGetSystemState
+    which is only enabled if configUSE_TRACE_FACILITY == 1.
+    Set #define configUSE_TRACE_FACILITY 1 to fix this error.
+    Alternatively, if the application does not use osThreadEnumerate it can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_ENUMERATE 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_ENUMERATE == 1)
+    #error "Definition configUSE_TRACE_FACILITY must equal 1 to implement osThreadEnumerate."
+  #endif
+#endif
+
+#if (configUSE_16_BIT_TICKS == 1)
+  /*
+    CMSIS-RTOS2 wrapper for FreeRTOS relies on 32-bit tick timer which is also optimal on
+    a 32-bit CPU architectures.
+    Set #define configUSE_16_BIT_TICKS 0 to fix this error.
+  */
+  #error "Definition configUSE_16_BIT_TICKS must be zero to implement CMSIS-RTOS2 API."
+#endif
+
+#if (configMAX_PRIORITIES != 56)
+  /*
+    CMSIS-RTOS2 defines 56 different priorities (see osPriority_t) and portable CMSIS-RTOS2
+    implementation should implement the same number of priorities.
+    Set #define configMAX_PRIORITIES 56 to fix this error.
+  */
+  #error "Definition configMAX_PRIORITIES must equal 56 to implement Thread Management API."
+#endif
+#if (configUSE_PORT_OPTIMISED_TASK_SELECTION != 0)
+  /*
+    CMSIS-RTOS2 requires handling of 56 different priorities (see osPriority_t) while FreeRTOS port
+    optimised selection for Cortex core only handles 32 different priorities.
+    Set #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0 to fix this error.
+  */
+  #error "Definition configUSE_PORT_OPTIMISED_TASK_SELECTION must be zero to implement Thread Management API."
 #endif
 
 #endif /* FREERTOS_OS2_H_ */

--- a/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------
- * Copyright (c) 2013-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -103,10 +103,8 @@ static osKernelState_t KernelState = osKernelInactive;
 
 /*
   Heap region definition used by heap_5 variant
-
   Define configAPPLICATION_ALLOCATED_HEAP as nonzero value in FreeRTOSConfig.h if
   heap regions are already defined and vPortDefineHeapRegions is called in application.
-
   Otherwise vPortDefineHeapRegions will be called by osKernelInitialize using
   definition configHEAP_5_REGIONS as parameter. Overriding configHEAP_5_REGIONS
   is possible by defining it globally or in FreeRTOSConfig.h.
@@ -465,14 +463,18 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
     }
 
     if (mem == 1) {
-      hTask = xTaskCreateStatic ((TaskFunction_t)func, name, stack, argument, prio, (StackType_t  *)attr->stack_mem,
-                                                                                    (StaticTask_t *)attr->cb_mem);
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        hTask = xTaskCreateStatic ((TaskFunction_t)func, name, stack, argument, prio, (StackType_t  *)attr->stack_mem,
+                                                                                      (StaticTask_t *)attr->cb_mem);
+      #endif
     }
     else {
       if (mem == 0) {
-        if (xTaskCreate ((TaskFunction_t)func, name, (uint16_t)stack, argument, prio, &hTask) != pdPASS) {
-          hTask = NULL;
-        }
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          if (xTaskCreate ((TaskFunction_t)func, name, (uint16_t)stack, argument, prio, &hTask) != pdPASS) {
+            hTask = NULL;
+          }
+        #endif
       }
     }
   }
@@ -580,6 +582,7 @@ osStatus_t osThreadYield (void) {
   return (stat);
 }
 
+#if (configUSE_OS2_THREAD_SUSPEND_RESUME == 1)
 osStatus_t osThreadSuspend (osThreadId_t thread_id) {
   TaskHandle_t hTask = (TaskHandle_t)thread_id;
   osStatus_t stat;
@@ -615,6 +618,7 @@ osStatus_t osThreadResume (osThreadId_t thread_id) {
 
   return (stat);
 }
+#endif /* (configUSE_OS2_THREAD_SUSPEND_RESUME == 1) */
 
 __NO_RETURN void osThreadExit (void) {
 #ifndef USE_FreeRTOS_HEAP_1
@@ -664,6 +668,7 @@ uint32_t osThreadGetCount (void) {
   return (count);
 }
 
+#if (configUSE_OS2_THREAD_ENUMERATE == 1)
 uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items) {
   uint32_t i, count;
   TaskStatus_t *task;
@@ -691,7 +696,9 @@ uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items) {
 
   return (count);
 }
+#endif /* (configUSE_OS2_THREAD_ENUMERATE == 1) */
 
+#if (configUSE_OS2_THREAD_FLAGS == 1)
 uint32_t osThreadFlagsSet (osThreadId_t thread_id, uint32_t flags) {
   TaskHandle_t hTask = (TaskHandle_t)thread_id;
   uint32_t rflags;
@@ -842,6 +849,7 @@ uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout) 
   /* Return flags before clearing */
   return (rflags);
 }
+#endif /* (configUSE_OS2_THREAD_FLAGS == 1) */
 
 osStatus_t osDelay (uint32_t ticks) {
   osStatus_t stat;
@@ -889,6 +897,7 @@ osStatus_t osDelayUntil (uint32_t ticks) {
 }
 
 /*---------------------------------------------------------------------------*/
+#if (configUSE_OS2_TIMER == 1)
 
 static void TimerCallback (TimerHandle_t hTimer) {
   TimerCallback_t *callb;
@@ -945,12 +954,20 @@ osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, 
       }
 
       if (mem == 1) {
-        hTimer = xTimerCreateStatic (name, 1, reload, callb, TimerCallback, (StaticTimer_t *)attr->cb_mem);
+        #if (configSUPPORT_STATIC_ALLOCATION == 1)
+          hTimer = xTimerCreateStatic (name, 1, reload, callb, TimerCallback, (StaticTimer_t *)attr->cb_mem);
+        #endif
       }
       else {
         if (mem == 0) {
-          hTimer = xTimerCreate (name, 1, reload, callb, TimerCallback);
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hTimer = xTimerCreate (name, 1, reload, callb, TimerCallback);
+          #endif
         }
+      }
+
+      if ((hTimer == NULL) && (callb != NULL)) {
+        vPortFree (callb);
       }
     }
   }
@@ -1059,6 +1076,7 @@ osStatus_t osTimerDelete (osTimerId_t timer_id) {
 
   return (stat);
 }
+#endif /* (configUSE_OS2_TIMER == 1) */
 
 /*---------------------------------------------------------------------------*/
 
@@ -1086,11 +1104,15 @@ osEventFlagsId_t osEventFlagsNew (const osEventFlagsAttr_t *attr) {
     }
 
     if (mem == 1) {
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
       hEventGroup = xEventGroupCreateStatic (attr->cb_mem);
+      #endif
     }
     else {
       if (mem == 0) {
-        hEventGroup = xEventGroupCreate();
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          hEventGroup = xEventGroupCreate();
+        #endif
       }
     }
   }
@@ -1107,6 +1129,11 @@ uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags) {
     rflags = (uint32_t)osErrorParameter;
   }
   else if (IS_IRQ()) {
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 0)
+    (void)yield;
+    /* Enable timers and xTimerPendFunctionCall function to support osEventFlagsSet from ISR */
+    rflags = (uint32_t)osErrorResource;
+  #else
     yield = pdFALSE;
 
     if (xEventGroupSetBitsFromISR (hEventGroup, (EventBits_t)flags, &yield) == pdFAIL) {
@@ -1115,6 +1142,7 @@ uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags) {
       rflags = flags;
       portYIELD_FROM_ISR (yield);
     }
+  #endif
   }
   else {
     rflags = xEventGroupSetBits (hEventGroup, (EventBits_t)flags);
@@ -1131,11 +1159,16 @@ uint32_t osEventFlagsClear (osEventFlagsId_t ef_id, uint32_t flags) {
     rflags = (uint32_t)osErrorParameter;
   }
   else if (IS_IRQ()) {
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 0)
+    /* Enable timers and xTimerPendFunctionCall function to support osEventFlagsSet from ISR */
+    rflags = (uint32_t)osErrorResource;
+  #else
     rflags = xEventGroupGetBitsFromISR (hEventGroup);
 
     if (xEventGroupClearBitsFromISR (hEventGroup, (EventBits_t)flags) == pdFAIL) {
       rflags = (uint32_t)osErrorResource;
     }
+  #endif
   }
   else {
     rflags = xEventGroupClearBits (hEventGroup, (EventBits_t)flags);
@@ -1234,6 +1267,7 @@ osStatus_t osEventFlagsDelete (osEventFlagsId_t ef_id) {
 }
 
 /*---------------------------------------------------------------------------*/
+#if (configUSE_OS2_MUTEX == 1)
 
 osMutexId_t osMutexNew (const osMutexAttr_t *attr) {
   SemaphoreHandle_t hMutex;
@@ -1277,20 +1311,28 @@ osMutexId_t osMutexNew (const osMutexAttr_t *attr) {
       }
 
       if (mem == 1) {
-        if (rmtx != 0U) {
-          hMutex = xSemaphoreCreateRecursiveMutexStatic (attr->cb_mem);
-        }
-        else {
-          hMutex = xSemaphoreCreateMutexStatic (attr->cb_mem);
-        }
+        #if (configSUPPORT_STATIC_ALLOCATION == 1)
+          if (rmtx != 0U) {
+            #if (configUSE_RECURSIVE_MUTEXES == 1)
+            hMutex = xSemaphoreCreateRecursiveMutexStatic (attr->cb_mem);
+            #endif
+          }
+          else {
+            hMutex = xSemaphoreCreateMutexStatic (attr->cb_mem);
+          }
+        #endif
       }
       else {
         if (mem == 0) {
-          if (rmtx != 0U) {
-            hMutex = xSemaphoreCreateRecursiveMutex ();
-          } else {
-            hMutex = xSemaphoreCreateMutex ();
-          }
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            if (rmtx != 0U) {
+              #if (configUSE_RECURSIVE_MUTEXES == 1)
+              hMutex = xSemaphoreCreateRecursiveMutex ();
+              #endif
+            } else {
+              hMutex = xSemaphoreCreateMutex ();
+            }
+          #endif
         }
       }
 
@@ -1333,6 +1375,7 @@ osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout) {
   }
   else {
     if (rmtx != 0U) {
+      #if (configUSE_RECURSIVE_MUTEXES == 1)
       if (xSemaphoreTakeRecursive (hMutex, timeout) != pdPASS) {
         if (timeout != 0U) {
           stat = osErrorTimeout;
@@ -1340,6 +1383,7 @@ osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout) {
           stat = osErrorResource;
         }
       }
+      #endif
     }
     else {
       if (xSemaphoreTake (hMutex, timeout) != pdPASS) {
@@ -1374,9 +1418,11 @@ osStatus_t osMutexRelease (osMutexId_t mutex_id) {
   }
   else {
     if (rmtx != 0U) {
+      #if (configUSE_RECURSIVE_MUTEXES == 1)
       if (xSemaphoreGiveRecursive (hMutex) != pdPASS) {
         stat = osErrorResource;
       }
+      #endif
     }
     else {
       if (xSemaphoreGive (hMutex) != pdPASS) {
@@ -1429,6 +1475,7 @@ osStatus_t osMutexDelete (osMutexId_t mutex_id) {
 
   return (stat);
 }
+#endif /* (configUSE_OS2_MUTEX == 1) */
 
 /*---------------------------------------------------------------------------*/
 
@@ -1461,10 +1508,14 @@ osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, cons
     if (mem != -1) {
       if (max_count == 1U) {
         if (mem == 1) {
-          hSemaphore = xSemaphoreCreateBinaryStatic ((StaticSemaphore_t *)attr->cb_mem);
+          #if (configSUPPORT_STATIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateBinaryStatic ((StaticSemaphore_t *)attr->cb_mem);
+          #endif
         }
         else {
-          hSemaphore = xSemaphoreCreateBinary();
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateBinary();
+          #endif
         }
 
         if ((hSemaphore != NULL) && (initial_count != 0U)) {
@@ -1476,10 +1527,14 @@ osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, cons
       }
       else {
         if (mem == 1) {
-          hSemaphore = xSemaphoreCreateCountingStatic (max_count, initial_count, (StaticSemaphore_t *)attr->cb_mem);
+          #if (configSUPPORT_STATIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateCountingStatic (max_count, initial_count, (StaticSemaphore_t *)attr->cb_mem);
+          #endif
         }
         else {
-          hSemaphore = xSemaphoreCreateCounting (max_count, initial_count);
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateCounting (max_count, initial_count);
+          #endif
         }
       }
       
@@ -1637,11 +1692,15 @@ osMessageQueueId_t osMessageQueueNew (uint32_t msg_count, uint32_t msg_size, con
     }
 
     if (mem == 1) {
-      hQueue = xQueueCreateStatic (msg_count, msg_size, attr->mq_mem, attr->cb_mem);
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        hQueue = xQueueCreateStatic (msg_count, msg_size, attr->mq_mem, attr->cb_mem);
+      #endif
     }
     else {
       if (mem == 0) {
-        hQueue = xQueueCreate (msg_count, msg_size);
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          hQueue = xQueueCreate (msg_count, msg_size);
+        #endif
       }
     }
 
@@ -1868,7 +1927,6 @@ osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, con
   const char *name;
   int32_t mem_cb, mem_mp;
   uint32_t sz;
-  SemaphoreHandle_t hSemaphore;
 
   if (IS_IRQ()) {
     mp = NULL;
@@ -1929,9 +1987,15 @@ osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, con
 
     if (mp != NULL) {
       /* Create a semaphore (max count == initial count == block_count) */
-      hSemaphore = xSemaphoreCreateCountingStatic (block_count, block_count, &mp->sem);
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        mp->sem = xSemaphoreCreateCountingStatic (block_count, block_count, &mp->mem_sem);
+      #elif (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+        mp->sem = xSemaphoreCreateCounting (block_count, block_count);
+      #else
+        mp->sem == NULL;
+      #endif
 
-      if (hSemaphore == (SemaphoreHandle_t)&mp->sem) {
+      if (mp->sem != NULL) {
         /* Setup memory array */
         if (mem_mp == 0) {
           mp->mem_arr = pvPortMalloc (sz);
@@ -2009,7 +2073,7 @@ void *osMemoryPoolAlloc (osMemoryPoolId_t mp_id, uint32_t timeout) {
     if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
       if (IS_IRQ()) {
         if (timeout == 0U) {
-          if (xSemaphoreTakeFromISR ((SemaphoreHandle_t)&mp->sem, NULL) == pdTRUE) {
+          if (xSemaphoreTakeFromISR (mp->sem, NULL) == pdTRUE) {
             if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
               isrm  = taskENTER_CRITICAL_FROM_ISR();
 
@@ -2027,7 +2091,7 @@ void *osMemoryPoolAlloc (osMemoryPoolId_t mp_id, uint32_t timeout) {
         }
       }
       else {
-        if (xSemaphoreTake ((SemaphoreHandle_t)&mp->sem, timeout) == pdTRUE) {
+        if (xSemaphoreTake (mp->sem, (TickType_t)timeout) == pdTRUE) {
           if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
             taskENTER_CRITICAL();
 
@@ -2074,7 +2138,7 @@ osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block) {
       stat = osOK;
 
       if (IS_IRQ()) {
-        if (uxSemaphoreGetCountFromISR ((SemaphoreHandle_t)&mp->sem) == mp->bl_cnt) {
+        if (uxSemaphoreGetCountFromISR (mp->sem) == mp->bl_cnt) {
           stat = osErrorResource;
         }
         else {
@@ -2086,12 +2150,12 @@ osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block) {
           taskEXIT_CRITICAL_FROM_ISR(isrm);
 
           yield = pdFALSE;
-          xSemaphoreGiveFromISR ((SemaphoreHandle_t)&mp->sem, &yield);
+          xSemaphoreGiveFromISR (mp->sem, &yield);
           portYIELD_FROM_ISR (yield);
         }
       }
       else {
-        if (uxSemaphoreGetCount ((SemaphoreHandle_t)&mp->sem) == mp->bl_cnt) {
+        if (uxSemaphoreGetCount (mp->sem) == mp->bl_cnt) {
           stat = osErrorResource;
         }
         else {
@@ -2102,7 +2166,7 @@ osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block) {
 
           taskEXIT_CRITICAL();
 
-          xSemaphoreGive ((SemaphoreHandle_t)&mp->sem);
+          xSemaphoreGive (mp->sem);
         }
       }
     }
@@ -2176,9 +2240,9 @@ uint32_t osMemoryPoolGetCount (osMemoryPoolId_t mp_id) {
     }
     else {
       if (IS_IRQ()) {
-        n = uxSemaphoreGetCountFromISR ((SemaphoreHandle_t)&mp->sem);
+        n = uxSemaphoreGetCountFromISR (mp->sem);
       } else {
-        n = uxSemaphoreGetCount        ((SemaphoreHandle_t)&mp->sem);
+        n = uxSemaphoreGetCount        (mp->sem);
       }
 
       n = mp->bl_cnt - n;
@@ -2206,9 +2270,9 @@ uint32_t osMemoryPoolGetSpace (osMemoryPoolId_t mp_id) {
     }
     else {
       if (IS_IRQ()) {
-        n = uxSemaphoreGetCountFromISR ((SemaphoreHandle_t)&mp->sem);
+        n = uxSemaphoreGetCountFromISR (mp->sem);
       } else {
-        n = uxSemaphoreGetCount        ((SemaphoreHandle_t)&mp->sem);
+        n = uxSemaphoreGetCount        (mp->sem);
       }
     }
   }
@@ -2237,7 +2301,7 @@ osStatus_t osMemoryPoolDelete (osMemoryPoolId_t mp_id) {
     mp->status  = mp->status & 3U;
 
     /* Wake-up tasks waiting for pool semaphore */
-    while (xSemaphoreGive ((SemaphoreHandle_t)&mp->sem) == pdTRUE);
+    while (xSemaphoreGive (mp->sem) == pdTRUE);
 
     mp->head    = NULL;
     mp->bl_sz   = 0U;
@@ -2264,7 +2328,7 @@ osStatus_t osMemoryPoolDelete (osMemoryPoolId_t mp_id) {
   Create new block given according to the current block index.
 */
 static void *CreateBlock (MemPool_t *mp) {
-  MPOOL_BLOCK *p = NULL;
+  MemPoolBlock_t *p = NULL;
 
   if (mp->n < mp->bl_cnt) {
     /* Unallocated blocks exist, set pointer to new block */
@@ -2281,7 +2345,7 @@ static void *CreateBlock (MemPool_t *mp) {
   Allocate a block by reading the list of free blocks.
 */
 static void *AllocBlock (MemPool_t *mp) {
-  MPOOL_BLOCK *p = NULL;
+  MemPoolBlock_t *p = NULL;
 
   if (mp->head != NULL) {
     /* List of free block exists, get head block */
@@ -2298,7 +2362,7 @@ static void *AllocBlock (MemPool_t *mp) {
   Free block by putting it to the list of free blocks.
 */
 static void FreeBlock (MemPool_t *mp, void *block) {
-  MPOOL_BLOCK *p = block;
+  MemPoolBlock_t *p = block;
 
   /* Store current head into block memory space */
   p->next = mp->head;
@@ -2356,7 +2420,7 @@ __WEAK void vApplicationStackOverflowHook (TaskHandle_t xTask, signed char *pcTa
 #endif
 
 /*---------------------------------------------------------------------------*/
-
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
 /* External Idle and Timer task static memory allocation functions */
 extern void vApplicationGetIdleTaskMemory  (StaticTask_t **ppxIdleTaskTCBBuffer,  StackType_t **ppxIdleTaskStackBuffer,  uint32_t *pulIdleTaskStackSize);
 extern void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize);
@@ -2388,3 +2452,4 @@ __WEAK void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer
   *ppxTimerTaskStackBuffer = &Timer_Stack[0];
   *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
 }
+#endif

--- a/CMSIS_5/CMSIS/RTOS2/Include/cmsis_os2.h
+++ b/CMSIS_5/CMSIS/RTOS2/Include/cmsis_os2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,7 +17,7 @@
  *
  * ----------------------------------------------------------------------
  *
- * $Date:        18. June 2018
+ * $Date:        12. June 2020
  * $Revision:    V2.1.3
  *
  * Project:      CMSIS-RTOS2 API
@@ -86,7 +86,7 @@ typedef enum {
   osKernelLocked          =  3,         ///< Locked.
   osKernelSuspended       =  4,         ///< Suspended.
   osKernelError           = -1,         ///< Error.
-  osKernelReserved        = 0x7FFFFFFFU ///< Prevents enum down-size compiler optimization.
+  osKernelReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
 } osKernelState_t;
  
 /// Thread state.
@@ -723,7 +723,7 @@ osStatus_t osMessageQueueGet (osMessageQueueId_t mq_id, void *msg_ptr, uint8_t *
 /// \return maximum number of messages.
 uint32_t osMessageQueueGetCapacity (osMessageQueueId_t mq_id);
  
-/// Get maximum message size in a Memory Pool.
+/// Get maximum message size in a Message Queue.
 /// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
 /// \return maximum message size in bytes.
 uint32_t osMessageQueueGetMsgSize (osMessageQueueId_t mq_id);

--- a/CMSIS_5/CMSIS/RTOS2/Include/os_tick.h
+++ b/CMSIS_5/CMSIS/RTOS2/Include/os_tick.h
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     os_tick.h
  * @brief    CMSIS OS Tick header file
- * @version  V1.0.1
- * @date     24. November 2017
+ * @version  V1.0.2
+ * @date     19. March 2021
  ******************************************************************************/
 /*
- * Copyright (c) 2017-2017 ARM Limited. All rights reserved.
+ * Copyright (c) 2017-2021 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -26,6 +26,11 @@
 #define OS_TICK_H
 
 #include <stdint.h>
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
 
 /// IRQ Handler.
 #ifndef IRQHANDLER_T
@@ -67,5 +72,9 @@ uint32_t OS_Tick_GetCount (void);
 /// Get OS Tick timer overflow status
 /// \return OS Tick overflow status (1 - overflow, 0 - no overflow).
 uint32_t OS_Tick_GetOverflow (void);
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif  /* OS_TICK_H */


### PR DESCRIPTION

**Comparing `thinnect/cmsis-freertos` versions - last updated on 12.2019, to current `master` branches of the original repos**.

**CMSIS_5**
- `zoo/thinnect.cmsis-freertos/CMSIS_5/CMSIS/RTOS2/Include/cmsis_os2.h`
	- typo correction in `osKernelState_t.osKernelReserved` struct field
	- added extern "C" in case of C++ compiler.
- `zoo/thinnect.cmsis-freertos/CMSIS_5/CMSIS/RTOS2/Include/os_tick.h`
	- added extern "C" in case of C++ compiler.
	
**CMSIS-FreeRTOS**
- `zoo/thinnect.cmsis-freertos/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h`
	- they have added new definitions (for finer-grain control), some of them for image size optimization (optional), as well as comments for all the includes.
- `zoo/thinnect.cmsis-freertos/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Include/freertos_mpool.h`
	- updated to FreeRTOS 10.3.1 
	- changed some Memory Pool implementation definitions. Now pool semaphore handles are not directly of type `StaticSemaphore_t`, but `SemaphoreHandle_t`, with the possibility to use a statically allocated one by setting the flag `configSUPPORT_STATIC_ALLOCATION` in `freertos_o2.h` (a new one compared to our current version).
- `zoo/thinnect.cmsis-freertos/CMSIS-FreeRTOS/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c`
	- some pre-processor directives spread over the code, to complement the new finer-grain options introduced in the `freertos_o2.h`. 
	- also the appropriate changes have been done to adapt to the less concrete Semaphore handle type.
 

All files above have been updated, I added a new required flag in the `node-apps` makefiles, and all apps are working on tsb2 and thunderboard2.
